### PR TITLE
Fix for pubkey hex and update in human-readable part comments

### DIFF
--- a/appendix/addresses.ipynb
+++ b/appendix/addresses.ipynb
@@ -427,12 +427,12 @@
     }
    ],
    "source": [
-    "pubkey = bytes.fromhex(\"02466d7fcae563e5cc09a0d1870bb580344804617879a14949cf22285f1bae3f27\")\n",
+    "pubkey = bytes.fromhex(\"02466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f27\")\n",
     "\n",
     "# Take the hash (hash160) of the pubkey\n",
     "pk_hash = hash160(pubkey)\n",
     "\n",
-    "# The human readable part for regtest\n",
+    "# The human readable part for testnet\n",
     "prefix = 'tb'\n",
     "\n",
     "# 0 for Segwit v0. The function below can also be used for encoding v1 (bech32m) addresses\n",
@@ -471,7 +471,7 @@
     "# Note that unlike P2SH which uses HASH160, for P2WSH we use SHA256\n",
     "script_hash = hashlib.sha256(redeemScript).digest()\n",
     "\n",
-    "# The human readable part for regtest\n",
+    "# The human readable part for mainnet\n",
     "prefix = 'bc'\n",
     "\n",
     "# 0 for Segwit v0. The function below can also be used for encoding v1 (bech32m) addresses\n",


### PR DESCRIPTION
While going through the appendix/addresses.ipynb, I noticed a couple of discrepancies that might cause confusion for other developers or lead to inaccurate results.

1- Updated the pubkey hex to the correct value.
2- Tweaked the comments to match the correct prefixes.

Thought this might help others avoid some confusion. Cheers!