### PR TITLE
changing the op code for Hash256

### DIFF
--- a/appendix/hash-functions.ipynb
+++ b/appendix/hash-functions.ipynb
@@ -74,7 +74,7 @@
    "id": "d738409d",
    "metadata": {},
    "source": [
-    "## HASH256 (OP_SHA256)\n",
+    "## HASH256 (OP_HASH256)\n",
     "HASH256 is simply two rounds of SHA256. The output of the first round is put directly into a second round of hashing. It is used as the hashing function behind proof of work mining, but it is also used in various places for creating transactions.\n",
     "\n",
     "Note that in many places bitcoind displays the output of SHA256 in little endian notation, such as the transaction id (txid) and block hash. In python we can reverse the order of bytes using the shorthand `[::-1]`. An example of doing such a is given below in `Example usage`, where we use it to display the txid in little endian."


### PR DESCRIPTION
This tutorial has helped so much. Here is something I noticed in the hash section

- I think the OP_CODE for double SHA256 hash should be OP_HASH256 and not OP_SHA256 as that is for single HASH