### PR TITLE
Fix nit typos

### DIFF
--- a/appendix/hash-functions.ipynb
+++ b/appendix/hash-functions.ipynb
@@ -199,7 +199,7 @@
    "metadata": {},
    "source": [
     "## Quiz\n",
-    "- Q1: The txid is calculated by performing two rounds of SHA-256 on the full txid hex (ignoring any witness fields). Given this tx hex for a p2pkh transaction. Which of the following is the txid? Note that bitcoind displays the txid in little endian notation.\n",
+    "- Q1: The txid is calculated by performing two rounds of SHA-256 on the full tx hex (ignoring any witness fields). Given this tx hex for a p2pkh transaction. Which of the following is the txid? Note that bitcoind displays the txid in little endian notation.\n",
     "    tx hex: `0100000001399434f3943d776250cf4b4c2b3fa2cac259dd5551a822e1976d25a2d9e0231d010000006b483045022100a628f785b81d\n",
     "04e3b5d2f4a554c839acab64215935a0558dda1e33d0120dada30220616acf4b1c796cebe11f30dd53bbb4354899d924a4791c8fd7c0ae3\n",
     "da0c4782c0121034f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aaffffffff0280d1f008000000001976a9\n",

--- a/chapter1-legacy/p2pkh.ipynb
+++ b/chapter1-legacy/p2pkh.ipynb
@@ -684,7 +684,7 @@
    ],
    "source": [
     "new_tx_txid = node.sendrawtransaction(signed_tx.hex())\n",
-    "# new_tx_txid = node.testmempoolaccept(signed_tx.hex())\n",
+    "# new_tx_txid = node.testmempoolaccept([signed_tx.hex()])\n",
     "\n",
     "print(new_tx_txid)"
    ]


### PR DESCRIPTION
Just some typos:
- naming the transaction as txid instead of tx
- missing [ ] at testmempoolaccept call parameter