### PR TITLE
Fix printing p2pkh instead of p2wpkh address

### DIFF
--- a/chapter2-segwitv0/p2wpkh.ipynb
+++ b/chapter2-segwitv0/p2wpkh.ipynb
@@ -551,9 +551,9 @@
     }
    ],
    "source": [
-    "print(\"receiver's p2pkh address: \" + receiver_address)\n",
-    "change_p2pkh_addr = pk_to_p2pkh(change_pubkey, network = \"regtest\")\n",
-    "print(\"sender's change p2pkh address: \" + change_p2pkh_addr)"
+    "print(\"receiver's p2wpkh address: \" + receiver_address)\n",
+    "change_p2wpkh_addr = pk_to_p2wpkh(change_pubkey, network = \"regtest\")\n",
+    "print(\"sender's change p2wpkh address: \" + change_p2wpkh_addr)"
    ]
   },
   {


### PR DESCRIPTION
IMHO Printing p2pkh instead of p2wpkh address might confuse the reader, cant check that the addresses are the same presented by the tx decoder.

